### PR TITLE
Removal of init() and addition of verbose flag

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -7,9 +7,3 @@ const (
 	Passes      = uint64(5)                  // Default number of shuffles of the tables
 	HashSize    = uint64(256)                // Default hash size.
 )
-
-var Lxrhash LXRHash
-
-func init() {
-	Lxrhash.Init(Seed, MapSizeBits, HashSize, Passes)
-}

--- a/lxrhash.go
+++ b/lxrhash.go
@@ -7,6 +7,7 @@ type LXRHash struct {
 	Passes      uint64 // Passes to generate the rand table
 	Seed        uint64 // An arbitrary number used to create the tables.
 	HashSize    uint64 // Number of bytes in the hash
+	verbose     bool
 }
 
 func (lx LXRHash) Hash(src []byte) []byte {

--- a/tables_test.go
+++ b/tables_test.go
@@ -1,0 +1,26 @@
+package lxr
+
+import (
+	"testing"
+	"time"
+)
+
+func Benchmark_GenerateTable(b *testing.B) {
+	b.Run("slow", func(b *testing.B) {
+		ByteMap := make([]byte, b.N)
+		period := time.Now().Unix()
+		for i := range ByteMap {
+			if (i+1)%1000 == 0 && time.Now().Unix()-period > 10 {
+				println(" Index ", i+1, " of ", len(lx.ByteMap))
+				period = time.Now().Unix()
+			}
+			ByteMap[i] = byte(i)
+		}
+	})
+	b.Run("fast", func(b *testing.B) {
+		ByteMap := make([]byte, b.N)
+		for i := range ByteMap {
+			ByteMap[i] = byte(i)
+		}
+	})
+}


### PR DESCRIPTION
This was a complaint in https://github.com/pegnet/pegnet/issues/87 and https://github.com/pegnet/LXRHash/issues/25#issuecomment-511271915

1. I removed the init() call in `constants.go` because the initialization of the hash should be done only when it's needed, not whenever the package is included

2. Replaced all of the StdOut output behind the wrapper function `lx.Log()` which checks whether or not verbose is enabled. we can decide what to do with the output later on. To enable the output, set `lx.Verbose(true)` before calling `lx.Init()`, and it's disabled by default

3. Removed the `period` timer when initializing the bytemap. It was supposed to report progress every 10 seconds, but that was too long and it never activated. Removing all the calls to time.Now() shaved about 1.7 seconds off the time to intialize a 1GB bytemap down to half a second. See benchmark:
```
Benchmark_GenerateTable/slow-8         	1000000000	         2.30 ns/op	       1 B/op	       0 allocs/op
Benchmark_GenerateTable/fast-8         	2000000000	         0.61 ns/op	       1 B/op	       0 allocs/op
```

4. Added a "total time taken" output at the end