### PR TITLE
LXR-36_Type_counters_to be_int64

### DIFF
--- a/testing/sha_compare_AddByte_test.go
+++ b/testing/sha_compare_AddByte_test.go
@@ -27,9 +27,9 @@ func AddByteTest() {
 	var g1 Gradehash
 	var g2 Gradehash
 
-	cnt := 0
+	cnt := int64(0)
 	last := time.Now().Unix()
-	for x := 0; x < 100000000000; x++ {
+	for int64(x) := 0; x < 100000000000; x++ {
 		// Get a new buffer of data.
 		buf := []byte{byte(x)}
 

--- a/testing/sha_compare_BitChange_test.go
+++ b/testing/sha_compare_BitChange_test.go
@@ -27,10 +27,10 @@ func BitChangeTest() {
 	var g1 Gradehash
 	var g2 Gradehash
 
-	cnt := 0
+	cnt := int64(0)
 
 	last := time.Now().Unix()
-	for x := 0; x < 100000000000; x++ {
+	for int64(x) := 0; x < 100000000000; x++ {
 		// Get a new buffer of data.
 		buf := Getbuf(1024)
 

--- a/testing/sha_compare_Count_test.go
+++ b/testing/sha_compare_Count_test.go
@@ -27,10 +27,10 @@ func BitCountTest() {
 	var g1 Gradehash
 	var g2 Gradehash
 
-	cnt := 0
+	cnt := int64(0)
 
 	last := time.Now().Unix()
-	for x := 0; x < 100000000000; x++ {
+	for int64(x) := 0; x < 100000000000; x++ {
 		// Get a new buffer of data.
 		buf := Getbuf(1024)
 

--- a/testing/sha_compare_DifferentHashes_test.go
+++ b/testing/sha_compare_DifferentHashes_test.go
@@ -28,8 +28,8 @@ func DifferentHashes() {
 	var g2 Gradehash
 
 	last := time.Now().Unix()
-	cnt := 0
-	for i := 1; i < 100000000000; i++ {
+	cnt := int64(0)
+	for int64(i) := 1; i < 100000000000; i++ {
 
 		// Get a new buffer of data.
 		buf := Getbuf(1024)


### PR DESCRIPTION
on 32 bit builds, int will overflow the very large limits set in the unit tests.