### PR TITLE
Truncating results for difficulty calculation

### DIFF
--- a/lxrhash.go
+++ b/lxrhash.go
@@ -13,8 +13,12 @@ type LXRHash struct {
 	verbose     bool
 }
 
-// Hash takes the arbitrary input and returns the resulting hash of length HashSize
 func (lx LXRHash) Hash(src []byte) []byte {
+	return lx.HashLimit(src, lx.HashSize)
+}
+
+// Hash takes the arbitrary input and returns the resulting hash of length HashSize
+func (lx LXRHash) HashLimit(src []byte, limit uint64) []byte {
 	// Keep the byte intermediate results as int64 values until reduced.
 	hs := make([]uint64, lx.HashSize)
 	// as accumulates the state as we walk through applying the source data through the lookup map
@@ -107,7 +111,7 @@ func (lx LXRHash) Hash(src []byte) []byte {
 
 	bytes := make([]byte, lx.HashSize)
 	// Roll over all the hs (one int64 value for every byte in the resulting hash) and reduce them to byte values
-	for i, h := range hs {
+	for i, h := range hs[:limit] {
 		step(h, uint64(i))          // Step the hash functions and then
 		bytes[i] = b(as) ^ b(hs[i]) // Xor two resulting sequences
 	}

--- a/lxrhash_test.go
+++ b/lxrhash_test.go
@@ -28,7 +28,7 @@ func BenchmarkHash(b *testing.B) {
 				nonce = append(nonce, byte(j))
 			}
 			no := append(oprhash, nonce...)
-			h := lx.Hash(no)
+			h := lx.HashLimit(no, lx.HashSize)
 
 			var difficulty uint64
 			for i := uint64(0); i < 8; i++ {

--- a/lxrhash_test.go
+++ b/lxrhash_test.go
@@ -2,13 +2,17 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 package lxr
 
-import "testing"
+import (
+	"crypto/rand"
+	"fmt"
+	"testing"
+)
 
 var lx LXRHash
 var oprhash []byte
 
 func init() {
-	lx.Init(0xfafaececfafaecec, 25, 256, 5)
+	lx.Init(0xfafaececfafaecec, 30, 256, 5)
 	oprhash = lx.Hash([]byte(`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dapibus pretium urna, mollis aliquet elit cursus ac. Sed sodales, erat ut volutpat viverra, ante urna pretium est, non congue augue dui sed purus. Mauris vitae mollis metus. Fusce convallis faucibus tempor. Maecenas hendrerit, urna eu lobortis venenatis, neque leo consequat enim, nec placerat tellus eros quis diam. Donec quis vestibulum eros. Maecenas id vulputate justo. Quisque nec feugiat nisi, lacinia pulvinar felis. Pellentesque habitant sed.`))
 }
 
@@ -27,4 +31,65 @@ func BenchmarkHash(b *testing.B) {
 			difficulty = difficulty<<8 + uint64(h[i])
 		}
 	}
+}
+
+func bLength(length int, b *testing.B) {
+	nonce := make([]byte, length)
+
+	b.Run(fmt.Sprintf("Hash length %d", length), func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			lx.Hash(nonce)
+		}
+	})
+}
+
+func BenchmarkLength(b *testing.B) {
+	for i := 50; i <= 50; i++ {
+		bLength(i, b)
+	}
+}
+
+// tldr: no difference in hashing zeros than hashing data, only length makes a difference
+func BenchmarkRandomVsNonRandom(b *testing.B) {
+	blank := make([]byte, 32)
+	rng1 := make([]byte, 32)
+	rng2 := make([]byte, 32)
+	rng3 := make([]byte, 32)
+	rng4 := make([]byte, 32)
+	rand.Read(rng1)
+	rand.Read(rng2)
+	rand.Read(rng3)
+	rand.Read(rng4)
+
+	b.Run("All zeroes", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			lx.Hash(blank)
+		}
+	})
+
+	b.Run("Random 1", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			lx.Hash(rng1)
+		}
+	})
+	b.Run("Random 2", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			lx.Hash(rng2)
+		}
+	})
+	b.Run("Random 3", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			lx.Hash(rng3)
+		}
+	})
+	b.Run("Random 4", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			lx.Hash(rng4)
+		}
+	})
+	b.Run("All zeroes again", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			lx.Hash(blank)
+		}
+	})
 }


### PR DESCRIPTION
Took another look at breaking the Hash algorithm and it turns out you can. Since you only need the first 8 bytes of the hash to calculate the difficulty, you only need to run 25% of the reduction pass. 

This has resulted in a dramatic increase of 60%:
```
BenchmarkHash/normal_hash-8         	   10000	    106006 ns/op	     351 B/op	       2 allocs/op
BenchmarkHash/limited_hash-8        	   50000	     42802 ns/op	     351 B/op	       2 allocs/op
```

There is a benchmark to compare the two and a unit test that checks the first 8 bytes are the same for both functions.

An easy solution would be to use the last 8 bytes for difficulty calculation OR run the reduction pass backwards. Both would ensure that the entire hash has to be calculated for the data to be available.