### PR TITLE
Reverse reduction pass

### DIFF
--- a/lxrhash.go
+++ b/lxrhash.go
@@ -107,8 +107,8 @@ func (lx LXRHash) Hash(src []byte) []byte {
 
 	bytes := make([]byte, lx.HashSize)
 	// Roll over all the hs (one int64 value for every byte in the resulting hash) and reduce them to byte values
-	for i, h := range hs {
-		step(h, uint64(i))          // Step the hash functions and then
+	for i := len(hs) - 1; i >= 0; i-- {
+		step(hs[i], uint64(i))      // Step the hash functions and then
 		bytes[i] = b(as) ^ b(hs[i]) // Xor two resulting sequences
 	}
 

--- a/lxrhash_test.go
+++ b/lxrhash_test.go
@@ -2,13 +2,17 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 package lxr
 
-import "testing"
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+)
 
 var lx LXRHash
 var oprhash []byte
 
 func init() {
-	lx.Init(0xfafaececfafaecec, 25, 256, 5)
+	lx.Init(0xfafaececfafaecec, 30, 256, 5)
 	oprhash = lx.Hash([]byte(`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dapibus pretium urna, mollis aliquet elit cursus ac. Sed sodales, erat ut volutpat viverra, ante urna pretium est, non congue augue dui sed purus. Mauris vitae mollis metus. Fusce convallis faucibus tempor. Maecenas hendrerit, urna eu lobortis venenatis, neque leo consequat enim, nec placerat tellus eros quis diam. Donec quis vestibulum eros. Maecenas id vulputate justo. Quisque nec feugiat nisi, lacinia pulvinar felis. Pellentesque habitant sed.`))
 }
 
@@ -27,4 +31,24 @@ func BenchmarkHash(b *testing.B) {
 			difficulty = difficulty<<8 + uint64(h[i])
 		}
 	}
+}
+
+func TestKnownHashes(t *testing.T) {
+
+	known := map[string]string{
+		"":       "66afa4d58ff4b99ef77f7bc2dc7567a23ccb47edab1486fccc3e9556bc64e9cc",
+		"foo":    "7dda54f8d5efcd6928870bdc9ece900b320e897bce4814e9010cc08647c197ae",
+		"bar":    "fe2cb7f3cef5702a1cb4712434085afe1efdef1d2563291e4883cd2a3ea1e074",
+		"pegnet": "cd45b08c0619d78e2a810c4e6462296ec51ae4fd0f73a54a154a97a54942297e",
+	}
+
+	for k, v := range known {
+		hash := lx.Hash([]byte(k))
+		val, _ := hex.DecodeString(v)
+
+		if bytes.Compare(hash, val) != 0 {
+			t.Errorf("mismatch for %s. got = %s, want = %s", k, hex.EncodeToString(hash), v)
+		}
+	}
+
 }


### PR DESCRIPTION
PR to fix the issue in https://github.com/pegnet/LXRHash/pull/40 by reversing the reduction pass. Also adds some unit tests with known hashes of the new function so that we have something to test changes against in the future.