### PR TITLE
Write ByteMap in 4KiB chunks to stop crashes

### DIFF
--- a/tables.go
+++ b/tables.go
@@ -3,6 +3,7 @@
 package lxr
 
 import (
+	"bufio"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -107,10 +108,21 @@ func (lx *LXRHash) WriteTable(filename string) {
 	}()
 
 	// write a chunk
-	if _, err := fo.Write(lx.ByteMap[:]); err != nil {
+	w := bufio.NewWriter(fo)
+	bufSize := 4096 // 4KiB
+	for i := 0; i < len(lx.ByteMap); i += bufSize {
+		j := i + bufSize
+		if j > len(lx.ByteMap) {
+			j = len(lx.ByteMap)
+		}
+		if nn, err := w.Write(lx.ByteMap[i:j]); err != nil {
+			panic(fmt.Sprintf("error writing bytemap to disk: %d bytes written, %v", nn, err))
+		}
+	}
+	err = w.Flush()
+	if err != nil {
 		panic(err)
 	}
-
 }
 
 // GenerateTable generates the bytemap.

--- a/tables_test.go
+++ b/tables_test.go
@@ -1,6 +1,9 @@
 package lxr
 
 import (
+	"bytes"
+	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 )
@@ -23,4 +26,78 @@ func Benchmark_GenerateTable(b *testing.B) {
 			ByteMap[i] = byte(i)
 		}
 	})
+}
+
+func (lx *LXRHash) OldWriteTable(filename string) {
+	os.Remove(filename)
+
+	// open output file
+	fo, err := os.Create(filename)
+	if err != nil {
+		panic(err)
+	}
+	// close fo on exit and check for its returned error
+	defer func() {
+		if err := fo.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	// write a chunk
+	if _, err := fo.Write(lx.ByteMap[:]); err != nil {
+		panic(err)
+	}
+
+}
+
+func compareWrite(t *testing.T, MapSizeBits uint64) {
+	l := new(LXRHash)
+
+	MapSize := uint64(1) << MapSizeBits
+	l.ByteMap = make([]byte, int(MapSize))
+
+	l.HashSize = (HashSize + 7) / 8
+	l.MapSize = MapSize
+	l.MapSizeBits = MapSizeBits
+	l.Seed = Seed
+	l.Passes = Passes
+	l.GenerateTable()
+
+	o, err := ioutil.TempFile("", "bytemapold")
+	defer os.Remove(o.Name())
+	if err != nil {
+		panic(err)
+	}
+	o.Close()
+
+	l.OldWriteTable(o.Name())
+
+	n, err := ioutil.TempFile("", "bytemapnew")
+	defer os.Remove(n.Name())
+	if err != nil {
+		panic(err)
+	}
+	n.Close()
+
+	l.WriteTable(n.Name())
+
+	a, err := ioutil.ReadFile(o.Name())
+	if err != nil {
+		panic(err)
+	}
+	b, err := ioutil.ReadFile(n.Name())
+	if err != nil {
+		panic(err)
+	}
+
+	if !bytes.Equal(a, b) {
+		t.Errorf("mismatch for %d bits. old = %32x, new = %32x", MapSizeBits, a, b)
+	}
+}
+
+func TestLXRHash_WriteTable(t *testing.T) {
+	compareWrite(t, 8)
+	compareWrite(t, 12)
+	compareWrite(t, 16)
+	compareWrite(t, 20)
 }


### PR DESCRIPTION
At the moment, the entire bytemap is written with a single call to file.Write, which is unbuffered. Some lower end systems have problems with this and crash. It's also slow. I rewrote the write-to-disk function to use bufio's buffered writer, using 4KiB chunks.

There are unit tests included that verify the bytemaps written are the same for 8, 12, 16, 20 bits and I have tested manually outside of unit tests that it's also the same for 25 and 30 bits.

The new algorithm is much faster at writing the file and has not crashed my old test hardware that was unable to write the hashmap previously. I believe this will allow RaspberryPi4s to generate the hashmap.

Writing the 1GiB bytemap to disk previously took me 5.5 seconds on average, with the new buffered writing it's 1.7 seconds on average (ymmv).