### PR TITLE
Factoring Out Closures

### DIFF
--- a/lxrhash.go
+++ b/lxrhash.go
@@ -6,12 +6,70 @@ package lxr
 type LXRHash struct {
 	ByteMap     []byte // Integer Offsets
 	MapSize     uint64 // Size of the translation table
+	MapMask     uint64 // Bit Mask of valid bytemap indices
 	MapSizeBits uint64 // Size of the ByteMap in Bits
 	Passes      uint64 // Passes to generate the rand table
 	Seed        uint64 // An arbitrary number used to create the tables.
 	HashSize    uint64 // Number of bytes in the hash
 	FirstIdx    uint64 // First Index used by LXRHash. (variance measures distribution of ByteMap access)
 	verbose     bool
+}
+
+// Byte retrieves a single byte from the HashMap for the specified index
+func (lx *LXRHash) Byte(v uint64) byte {
+	return lx.ByteMap[v&lx.MapMask]
+}
+
+// UByte retrieves a single byte as uint64 from the HashMap for the specified index
+func (lx *LXRHash) UByte(v uint64) uint64 {
+	return uint64(lx.ByteMap[v&lx.MapMask])
+}
+
+func (lx *LXRHash) faststep(hs []uint64, as, s1, s2, s3, v2, idx uint64) (uint64, uint64, uint64, uint64) {
+	b := lx.UByte(as ^ v2)
+	as = as<<7 ^ as>>5 ^ v2<<20 ^ v2<<16 ^ v2 ^ b<<20 ^ b<<12 ^ b<<4
+	s1 = s1<<9 ^ s1>>3 ^ hs[idx]
+	hs[idx] = s1 ^ as
+	return as, s3, s1, s2
+}
+
+func (lx *LXRHash) step(hs []uint64, as, s1, s2, s3, v2, idx uint64) (uint64, uint64, uint64, uint64) {
+	s1 = s1<<9 ^ s1>>1 ^ as ^ lx.UByte(as>>5^v2)<<3      // Shifts are not random.  They are selected to ensure that
+	s1 = s1<<5 ^ s1>>3 ^ lx.UByte(s1^v2)<<7              // Prior bytes pulled from the ByteMap contribute to the
+	s1 = s1<<7 ^ s1>>7 ^ lx.UByte(as^s1>>7)<<5           // next access of the ByteMap, either by contributing to
+	s1 = s1<<11 ^ s1>>5 ^ lx.UByte(v2^as>>11^s1)<<27     // the lower bits of the index, or in the upper bits that
+	_ = 0                                                // move the access further in the map.
+	hs[idx] = s1 ^ as ^ hs[idx]<<7 ^ hs[idx]>>13         //
+	_ = 0                                                // We also pay attention not only to where the ByteMap bits
+	as = as<<17 ^ as>>5 ^ s1 ^ lx.UByte(as^s1>>27^v2)<<3 // are applied, but what bits we use in the indexing of
+	as = as<<13 ^ as>>3 ^ lx.UByte(as^s1)<<7             // the ByteMap
+	as = as<<15 ^ as>>7 ^ lx.UByte(as>>7^s1)<<11         //
+	as = as<<9 ^ as>>11 ^ lx.UByte(v2^as^s1)<<3          // Tests run against this set of shifts show that the
+	_ = 0                                                // bytes pulled from the ByteMap are evenly distributed
+	s1 = s1<<7 ^ s1>>27 ^ as ^ lx.UByte(as>>3)<<13       // over possible byte values (0-255) and indexes into
+	s1 = s1<<3 ^ s1>>13 ^ lx.UByte(s1^v2)<<11            // the ByteMap are also evenly distributed, and the
+	s1 = s1<<8 ^ s1>>11 ^ lx.UByte(as^s1>>11)<<9         // deltas between bytes provided map to a curve expected
+	s1 = s1<<6 ^ s1>>9 ^ lx.UByte(v2^as^s1)<<3           // (fewer maximum and minimum deltas, and most deltas around
+	_ = 0                                                // zero.
+	as = as<<23 ^ as>>3 ^ s1 ^ lx.UByte(as^v2^s1>>3)<<7
+	as = as<<17 ^ as>>7 ^ lx.UByte(as^s1>>3)<<5
+	as = as<<13 ^ as>>5 ^ lx.UByte(as>>5^s1)<<1
+	as = as<<11 ^ as>>1 ^ lx.UByte(v2^as^s1)<<7
+
+	s1 = s1<<5 ^ s1>>3 ^ as ^ lx.UByte(as>>7^s1>>3)<<6
+	s1 = s1<<8 ^ s1>>6 ^ lx.UByte(s1^v2)<<11
+	s1 = s1<<11 ^ s1>>11 ^ lx.UByte(as^s1>>11)<<5
+	s1 = s1<<7 ^ s1>>5 ^ lx.UByte(v2^as>>7^as^s1)<<17
+
+	s2 = s2<<3 ^ s2>>17 ^ s1 ^ lx.UByte(as^s2>>5^v2)<<13
+	s2 = s2<<6 ^ s2>>13 ^ lx.UByte(s2)<<11
+	s2 = s2<<11 ^ s2>>11 ^ lx.UByte(as^s1^s2>>11)<<23
+	s2 = s2<<4 ^ s2>>23 ^ lx.UByte(v2^as>>8^as^s2>>10)<<1
+
+	s1 = s2<<3 ^ s2>>1 ^ hs[idx] ^ v2
+	as = as<<9 ^ as>>7 ^ s1>>1 ^ lx.UByte(s2>>1^hs[idx])<<5
+
+	return as, s3, s1, s2
 }
 
 // Hash takes the arbitrary input and returns the resulting hash of length HashSize
@@ -24,62 +82,12 @@ func (lx *LXRHash) Hash(src []byte) []byte {
 	// We keep a series of states, and roll them along through each byte of source processed.
 	var s1, s2, s3 uint64
 	// Since MapSize is specified in bits, the index mask is the size-1
-	mk := lx.MapSize - 1
-
-	B := func(v uint64) uint64 { return uint64(lx.ByteMap[v&mk]) }
-	b := func(v uint64) byte { return byte(B(v)) }
-
-	faststep := func(v2 uint64, idx uint64) {
-		b := B(as ^ v2)
-		as = as<<7 ^ as>>5 ^ v2<<20 ^ v2<<16 ^ v2 ^ b<<20 ^ b<<12 ^ b<<4
-		s1 = s1<<9 ^ s1>>3 ^ hs[idx]
-		hs[idx] = s1 ^ as
-		s1, s2, s3 = s3, s1, s2
-	}
 
 	// Define a function to move the state by one byte.  This is not intended to be fast
 	// Requires the previous byte read to process the next byte read.  Forces serial evaluation
 	// and removes the possibility of scheduling byte access.
 	//
 	// (Note that use of _ = 0 in lines below are to keep go fmt from messing with comments on the right of the page)
-	step := func(v2 uint64, idx uint64) {
-		s1 = s1<<9 ^ s1>>1 ^ as ^ B(as>>5^v2)<<3      // Shifts are not random.  They are selected to ensure that
-		s1 = s1<<5 ^ s1>>3 ^ B(s1^v2)<<7              // Prior bytes pulled from the ByteMap contribute to the
-		s1 = s1<<7 ^ s1>>7 ^ B(as^s1>>7)<<5           // next access of the ByteMap, either by contributing to
-		s1 = s1<<11 ^ s1>>5 ^ B(v2^as>>11^s1)<<27     // the lower bits of the index, or in the upper bits that
-		_ = 0                                         // move the access further in the map.
-		hs[idx] = s1 ^ as ^ hs[idx]<<7 ^ hs[idx]>>13  //
-		_ = 0                                         // We also pay attention not only to where the ByteMap bits
-		as = as<<17 ^ as>>5 ^ s1 ^ B(as^s1>>27^v2)<<3 // are applied, but what bits we use in the indexing of
-		as = as<<13 ^ as>>3 ^ B(as^s1)<<7             // the ByteMap
-		as = as<<15 ^ as>>7 ^ B(as>>7^s1)<<11         //
-		as = as<<9 ^ as>>11 ^ B(v2^as^s1)<<3          // Tests run against this set of shifts show that the
-		_ = 0                                         // bytes pulled from the ByteMap are evenly distributed
-		s1 = s1<<7 ^ s1>>27 ^ as ^ B(as>>3)<<13       // over possible byte values (0-255) and indexes into
-		s1 = s1<<3 ^ s1>>13 ^ B(s1^v2)<<11            // the ByteMap are also evenly distributed, and the
-		s1 = s1<<8 ^ s1>>11 ^ B(as^s1>>11)<<9         // deltas between bytes provided map to a curve expected
-		s1 = s1<<6 ^ s1>>9 ^ B(v2^as^s1)<<3           // (fewer maximum and minimum deltas, and most deltas around
-		_ = 0                                         // zero.
-		as = as<<23 ^ as>>3 ^ s1 ^ B(as^v2^s1>>3)<<7
-		as = as<<17 ^ as>>7 ^ B(as^s1>>3)<<5
-		as = as<<13 ^ as>>5 ^ B(as>>5^s1)<<1
-		as = as<<11 ^ as>>1 ^ B(v2^as^s1)<<7
-
-		s1 = s1<<5 ^ s1>>3 ^ as ^ B(as>>7^s1>>3)<<6
-		s1 = s1<<8 ^ s1>>6 ^ B(s1^v2)<<11
-		s1 = s1<<11 ^ s1>>11 ^ B(as^s1>>11)<<5
-		s1 = s1<<7 ^ s1>>5 ^ B(v2^as>>7^as^s1)<<17
-
-		s2 = s2<<3 ^ s2>>17 ^ s1 ^ B(as^s2>>5^v2)<<13
-		s2 = s2<<6 ^ s2>>13 ^ B(s2)<<11
-		s2 = s2<<11 ^ s2>>11 ^ B(as^s1^s2>>11)<<23
-		s2 = s2<<4 ^ s2>>23 ^ B(v2^as>>8^as^s2>>10)<<1
-
-		s1 = s2<<3 ^ s2>>1 ^ hs[idx] ^ v2
-		as = as<<9 ^ as>>7 ^ s1>>1 ^ B(s2>>1^hs[idx])<<5
-
-		s1, s2, s3 = s3, s1, s2
-	}
 
 	idx := uint64(0)
 	// Fast spin to prevent caching state
@@ -87,7 +95,7 @@ func (lx *LXRHash) Hash(src []byte) []byte {
 		if idx >= lx.HashSize { // Use an if to avoid modulo math
 			idx = 0
 		}
-		faststep(uint64(v2), idx)
+		as, s1, s2, s3 = lx.faststep(hs, as, s1, s2, s3, uint64(v2), idx)
 		idx++
 	}
 
@@ -98,9 +106,9 @@ func (lx *LXRHash) Hash(src []byte) []byte {
 			idx = 0
 		}
 		if i == 0 {
-			lx.FirstIdx = (as>>5 ^ uint64(v2)) & mk
+			lx.FirstIdx = (as>>5 ^ uint64(v2)) & lx.MapMask
 		}
-		step(uint64(v2), idx)
+		as, s1, s2, s3 = lx.step(hs, as, s1, s2, s3, uint64(v2), idx)
 		idx++
 	}
 
@@ -113,8 +121,8 @@ func (lx *LXRHash) Hash(src []byte) []byte {
 	bytes := make([]byte, lx.HashSize)
 	// Roll over all the hs (one int64 value for every byte in the resulting hash) and reduce them to byte values
 	for i := len(hs) - 1; i >= 0; i-- {
-		step(hs[i], uint64(i))      // Step the hash functions and then
-		bytes[i] = b(as) ^ b(hs[i]) // Xor two resulting sequences
+		as, s1, s2, s3 = lx.step(hs, as, s1, s2, s3, hs[i], uint64(i)) // Step the hash functions and then
+		bytes[i] = lx.Byte(as) ^ lx.Byte(hs[i])                        // Xor two resulting sequences
 	}
 
 	// Return the resulting hash

--- a/lxrhash.go
+++ b/lxrhash.go
@@ -136,3 +136,109 @@ func (lx *LXRHash) Hash(src []byte) []byte {
 	// Return the resulting hash
 	return bytes
 }
+
+func (lx *LXRHash) HashClosures(src []byte) []byte {
+	// Keep the byte intermediate results as int64 values until reduced.
+	hs := make([]uint64, lx.HashSize)
+	// as accumulates the state as we walk through applying the source data through the lookup map
+	// and combine it with the state we are building up.
+	var as = lx.Seed
+	// We keep a series of states, and roll them along through each byte of source processed.
+	var s1, s2, s3 uint64
+	// Since MapSize is specified in bits, the index mask is the size-1
+	mk := lx.MapSize - 1
+
+	B := func(v uint64) uint64 { return uint64(lx.ByteMap[v&mk]) }
+	b := func(v uint64) byte { return byte(B(v)) }
+
+	faststep := func(v2 uint64, idx uint64) {
+		b := B(as ^ v2)
+		as = as<<7 ^ as>>5 ^ v2<<20 ^ v2<<16 ^ v2 ^ b<<20 ^ b<<12 ^ b<<4
+		s1 = s1<<9 ^ s1>>3 ^ hs[idx]
+		hs[idx] = s1 ^ as
+		s1, s2, s3 = s3, s1, s2
+	}
+
+	// Define a function to move the state by one byte.  This is not intended to be fast
+	// Requires the previous byte read to process the next byte read.  Forces serial evaluation
+	// and removes the possibility of scheduling byte access.
+	//
+	// (Note that use of _ = 0 in lines below are to keep go fmt from messing with comments on the right of the page)
+	step := func(v2 uint64, idx uint64) {
+		s1 = s1<<9 ^ s1>>1 ^ as ^ B(as>>5^v2)<<3      // Shifts are not random.  They are selected to ensure that
+		s1 = s1<<5 ^ s1>>3 ^ B(s1^v2)<<7              // Prior bytes pulled from the ByteMap contribute to the
+		s1 = s1<<7 ^ s1>>7 ^ B(as^s1>>7)<<5           // next access of the ByteMap, either by contributing to
+		s1 = s1<<11 ^ s1>>5 ^ B(v2^as>>11^s1)<<27     // the lower bits of the index, or in the upper bits that
+		_ = 0                                         // move the access further in the map.
+		hs[idx] = s1 ^ as ^ hs[idx]<<7 ^ hs[idx]>>13  //
+		_ = 0                                         // We also pay attention not only to where the ByteMap bits
+		as = as<<17 ^ as>>5 ^ s1 ^ B(as^s1>>27^v2)<<3 // are applied, but what bits we use in the indexing of
+		as = as<<13 ^ as>>3 ^ B(as^s1)<<7             // the ByteMap
+		as = as<<15 ^ as>>7 ^ B(as>>7^s1)<<11         //
+		as = as<<9 ^ as>>11 ^ B(v2^as^s1)<<3          // Tests run against this set of shifts show that the
+		_ = 0                                         // bytes pulled from the ByteMap are evenly distributed
+		s1 = s1<<7 ^ s1>>27 ^ as ^ B(as>>3)<<13       // over possible byte values (0-255) and indexes into
+		s1 = s1<<3 ^ s1>>13 ^ B(s1^v2)<<11            // the ByteMap are also evenly distributed, and the
+		s1 = s1<<8 ^ s1>>11 ^ B(as^s1>>11)<<9         // deltas between bytes provided map to a curve expected
+		s1 = s1<<6 ^ s1>>9 ^ B(v2^as^s1)<<3           // (fewer maximum and minimum deltas, and most deltas around
+		_ = 0                                         // zero.
+		as = as<<23 ^ as>>3 ^ s1 ^ B(as^v2^s1>>3)<<7
+		as = as<<17 ^ as>>7 ^ B(as^s1>>3)<<5
+		as = as<<13 ^ as>>5 ^ B(as>>5^s1)<<1
+		as = as<<11 ^ as>>1 ^ B(v2^as^s1)<<7
+
+		s1 = s1<<5 ^ s1>>3 ^ as ^ B(as>>7^s1>>3)<<6
+		s1 = s1<<8 ^ s1>>6 ^ B(s1^v2)<<11
+		s1 = s1<<11 ^ s1>>11 ^ B(as^s1>>11)<<5
+		s1 = s1<<7 ^ s1>>5 ^ B(v2^as>>7^as^s1)<<17
+
+		s2 = s2<<3 ^ s2>>17 ^ s1 ^ B(as^s2>>5^v2)<<13
+		s2 = s2<<6 ^ s2>>13 ^ B(s2)<<11
+		s2 = s2<<11 ^ s2>>11 ^ B(as^s1^s2>>11)<<23
+		s2 = s2<<4 ^ s2>>23 ^ B(v2^as>>8^as^s2>>10)<<1
+
+		s1 = s2<<3 ^ s2>>1 ^ hs[idx] ^ v2
+		as = as<<9 ^ as>>7 ^ s1>>1 ^ B(s2>>1^hs[idx])<<5
+
+		s1, s2, s3 = s3, s1, s2
+	}
+
+	idx := uint64(0)
+	// Fast spin to prevent caching state
+	for _, v2 := range src {
+		if idx >= lx.HashSize { // Use an if to avoid modulo math
+			idx = 0
+		}
+		faststep(uint64(v2), idx)
+		idx++
+	}
+
+	idx = 0
+	// Actual work to compute the hash
+	for i, v2 := range src {
+		if idx >= lx.HashSize { // Use an if to avoid modulo math
+			idx = 0
+		}
+		if i == 0 {
+			lx.FirstIdx = (as>>5 ^ uint64(v2)) & mk
+		}
+		step(uint64(v2), idx)
+		idx++
+	}
+
+	// Reduction pass
+	// Done by Interating over hs[] to produce the bytes[] hash
+	//
+	// At this point, we have HBits of state in hs.  We need to reduce them down to a byte,
+	// And we do so by doing a bit more bitwise math, and mapping the values through our byte map.
+
+	bytes := make([]byte, lx.HashSize)
+	// Roll over all the hs (one int64 value for every byte in the resulting hash) and reduce them to byte values
+	for i := len(hs) - 1; i >= 0; i-- {
+		step(hs[i], uint64(i))      // Step the hash functions and then
+		bytes[i] = b(as) ^ b(hs[i]) // Xor two resulting sequences
+	}
+
+	// Return the resulting hash
+	return bytes
+}

--- a/lxrhash_test.go
+++ b/lxrhash_test.go
@@ -5,6 +5,7 @@ package lxr
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
 	"testing"
 )
 
@@ -15,30 +16,20 @@ func init() {
 	lx.Init(0xfafaececfafaecec, 30, 256, 5)
 	oprhash = lx.Hash([]byte(`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc dapibus pretium urna, mollis aliquet elit cursus ac. Sed sodales, erat ut volutpat viverra, ante urna pretium est, non congue augue dui sed purus. Mauris vitae mollis metus. Fusce convallis faucibus tempor. Maecenas hendrerit, urna eu lobortis venenatis, neque leo consequat enim, nec placerat tellus eros quis diam. Donec quis vestibulum eros. Maecenas id vulputate justo. Quisque nec feugiat nisi, lacinia pulvinar felis. Pellentesque habitant sed.`))
 }
-
 func BenchmarkHash(b *testing.B) {
-	b.Run("hash", func(b *testing.B) {
-		nonce := []byte{0, 0}
-		for i := 0; i < b.N; i++ {
-			nonce = nonce[:0]
-			for j := i; j > 0; j = j >> 8 {
-				nonce = append(nonce, byte(j))
+	for i := 0; i < 10; i++ {
+		b.Run(fmt.Sprintf("hash run %d", i), func(b *testing.B) {
+			nonce := []byte{0, 0}
+			for i := 0; i < b.N; i++ {
+				nonce = nonce[:0]
+				for j := i; j > 0; j = j >> 8 {
+					nonce = append(nonce, byte(j))
+				}
+				no := append(oprhash, nonce...)
+				lx.Hash(no)
 			}
-			no := append(oprhash, nonce...)
-			lx.Hash(no)
-		}
-	})
-	b.Run("hash again", func(b *testing.B) {
-		nonce := []byte{0, 0}
-		for i := 0; i < b.N; i++ {
-			nonce = nonce[:0]
-			for j := i; j > 0; j = j >> 8 {
-				nonce = append(nonce, byte(j))
-			}
-			no := append(oprhash, nonce...)
-			lx.Hash(no)
-		}
-	})
+		})
+	}
 }
 
 func TestKnownHashes(t *testing.T) {

--- a/simMiner2/main.go
+++ b/simMiner2/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"runtime"
+	"sync/atomic"
+	"time"
+
+	lxr "github.com/pegnet/LXRHash"
+)
+
+var total uint64
+var lx *lxr.LXRHash
+
+func minerRefactor(base []byte, id int) {
+	ninc := NewNonceIncrementer(id)
+	var data []byte
+	for {
+		ninc.NextNonce()
+		data = append(base, ninc.Nonce...)
+		lx.Hash(data)
+		atomic.AddUint64(&total, 1)
+	}
+}
+
+func minerClosures(base []byte, id int) {
+	ninc := NewNonceIncrementer(id)
+	var data []byte
+	for {
+		ninc.NextNonce()
+		data = append(base, ninc.Nonce...)
+		lx.HashClosures(data)
+		atomic.AddUint64(&total, 1)
+	}
+}
+
+func main() {
+	lx = new(lxr.LXRHash)
+	lx.Init(lxr.Seed, lxr.MapSizeBits, lxr.HashSize, lxr.Passes)
+
+	base := sha256.Sum256([]byte("foo"))
+
+	closures := false
+	if len(os.Args) > 1 && os.Args[1] == "true" {
+		closures = true
+	}
+
+	fmt.Println("Using closures?", closures)
+	fmt.Println(runtime.Version())
+
+	start := time.Now()
+	for i := 0; i < runtime.NumCPU(); i++ {
+		if closures {
+			go minerClosures(base[:], i)
+		} else {
+			go minerRefactor(base[:], i)
+		}
+	}
+
+	for i := 0; i < 60; i++ {
+		time.Sleep(10 * time.Second)
+		since := time.Since(start)
+		fmt.Printf("%s\t%d h\t%.0f hps\n", since, total, float64(total)/since.Seconds())
+	}
+}

--- a/simMiner2/nonceIncrementer.go
+++ b/simMiner2/nonceIncrementer.go
@@ -1,0 +1,34 @@
+package main
+
+type NonceIncrementer struct {
+	Nonce         []byte
+	lastNonceByte int
+}
+
+func NewNonceIncrementer(id int) *NonceIncrementer {
+	n := new(NonceIncrementer)
+	n.Nonce = []byte{byte(id), 0}
+	n.lastNonceByte = 1
+	return n
+}
+
+// NextNonce is just counting to get the next nonce. We preserve
+// the first byte, as that is our ID and give us our nonce space
+//	So []byte(ID, 255) -> []byte(ID, 1, 0) -> []byte(ID, 1, 1)
+func (i *NonceIncrementer) NextNonce() {
+	idx := len(i.Nonce) - 1
+	for {
+		i.Nonce[idx]++
+		if i.Nonce[idx] == 0 {
+			idx--
+			if idx == 0 { // This is my prefix, don't touch it!
+				rest := append([]byte{1}, i.Nonce[1:]...)
+				i.Nonce = append([]byte{i.Nonce[0]}, rest...)
+				break
+			}
+		} else {
+			break
+		}
+	}
+
+}

--- a/tables.go
+++ b/tables.go
@@ -51,6 +51,7 @@ func (lx *LXRHash) Init(Seed, MapSizeBits, HashSize, Passes uint64) {
 
 	lx.HashSize = (HashSize + 7) / 8
 	lx.MapSize = MapSize
+	lx.MapMask = MapSize - 1
 	lx.MapSizeBits = MapSizeBits
 	lx.Seed = Seed
 	lx.Passes = Passes


### PR DESCRIPTION
Since the algorithm itself is unlikely to be changed, I'm proposing to once again factor out the closures in order to speed up the algorithm and ensure all miners are on an even playing field.

Closures are not that great and right now, a call to Hash will instantiate 4 separate closures (faststep, step, b, B). I made them their own functions. This yields a speed increase of approximately 5%:

Before refactor
```
BenchmarkHash/hash_run_0-8                 10000            153208 ns/op
BenchmarkHash/hash_run_1-8                 10000            152108 ns/op
BenchmarkHash/hash_run_2-8                 10000            151708 ns/op
BenchmarkHash/hash_run_3-8                 10000            152108 ns/op
BenchmarkHash/hash_run_4-8                 10000            151108 ns/op
BenchmarkHash/hash_run_5-8                 10000            153408 ns/op
BenchmarkHash/hash_run_6-8                 10000            150908 ns/op
BenchmarkHash/hash_run_7-8                 10000            152208 ns/op
BenchmarkHash/hash_run_8-8                 10000            151908 ns/op
BenchmarkHash/hash_run_9-8                 10000            151808 ns/op

201379 hashes in 30 seconds with 1 threads
398845 hashes in 30 seconds with 2 threads
589711 hashes in 30 seconds with 3 threads
780025 hashes in 30 seconds with 4 threads
```

after
```
BenchmarkHash/hash_run_0-8                 10000            146608 ns/op
BenchmarkHash/hash_run_1-8                 10000            145308 ns/op
BenchmarkHash/hash_run_2-8                 10000            144308 ns/op
BenchmarkHash/hash_run_3-8                 10000            144408 ns/op
BenchmarkHash/hash_run_4-8                 10000            144508 ns/op
BenchmarkHash/hash_run_5-8                 10000            146308 ns/op
BenchmarkHash/hash_run_6-8                 10000            145308 ns/op
BenchmarkHash/hash_run_7-8                 10000            144908 ns/op
BenchmarkHash/hash_run_8-8                 10000            144808 ns/op
BenchmarkHash/hash_run_9-8                 10000            144608 ns/op

209857 hashes in 30 seconds with 1 threads
414493 hashes in 30 seconds with 2 threads
614482 hashes in 30 seconds with 3 threads
812155 hashes in 30 seconds with 4 threads
```