### PR TITLE
Singleton instances of lxrhash

### DIFF
--- a/singletons.go
+++ b/singletons.go
@@ -1,0 +1,38 @@
+package lxr
+
+// The goal of instances is to provide a way for multiple packages to use LXR without
+// instantiating multiple bytemaps in memory or having to share references
+
+var instances map[uint64]*LXRHash
+
+func init() {
+	instances = make(map[uint64]*LXRHash)
+}
+
+// Init provides access to shared instances of LXRHash without having to instantiate multiple bytemaps.
+// Two separate calls to Init(n) will result in a reference to the same object.
+// LXRHash will be instantiated with the package defaults of:
+// 	* Seed: 0xFAFAECECFAFAECEC
+// 	* Hash Size: 256
+// 	* Passes: 5
+func Init(bitsize uint64) *LXRHash {
+	if bitsize < 8 {
+		panic("bitsize must be at least 8")
+	}
+
+	if instance, ok := instances[bitsize]; ok {
+		return instance
+	}
+
+	lxr := new(LXRHash)
+	lxr.Verbose(true)
+	lxr.Init(Seed, bitsize, HashSize, Passes)
+	instances[bitsize] = lxr
+	return lxr
+}
+
+// Release dereferences the shared instance inside this package, allowing the garbage collector to free the memory.
+// Please note that any existing references to the instance outside this package will keep it alive
+func Release(bitsize uint64) {
+	delete(instances, bitsize)
+}

--- a/singletons_test.go
+++ b/singletons_test.go
@@ -1,0 +1,55 @@
+package lxr
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func testSize(t *testing.T, bits uint64, buf []byte, reference string) {
+	one := Init(bits)
+	two := Init(bits)
+
+	if one != two {
+		t.Errorf("[%d] two separate pointers for singleton: %x and %x", bits, &one, &two)
+	}
+
+	three := new(LXRHash)
+	three.Init(Seed, bits, HashSize, Passes)
+
+	if one == three {
+		t.Errorf("[%d] separate instance is the same as singleton: %x and %x", bits, &one, &three)
+	}
+
+	res := fmt.Sprintf("%x", one.Hash(buf))
+	if res != reference {
+		t.Errorf("[%d] incorrect hash result, want = %s got = %s", bits, reference, res)
+	}
+
+	if !bytes.Equal(one.Hash(buf), two.Hash(buf)) {
+		t.Errorf("[%d] one and two provided different hash results", bits)
+	}
+	if !bytes.Equal(one.Hash(buf), three.Hash(buf)) {
+		t.Errorf("[%d] one and three provided different hash results", bits)
+	}
+}
+
+func TestInit(t *testing.T) {
+	buf := []byte("test string")
+
+	testSize(t, 8, buf, "abab21b95cee68a5d70d871161e092530638b3b4bd4e88cadab3a5d6bbcf5f80")
+	testSize(t, 9, buf, "c56d9652bc709713af194e2a64e0e2ff1bc0980b2395c772187186fbbf6cf9a9")
+	testSize(t, 10, buf, "3c7df3fac7481d630571926c9be01056b36822baccdf2b1872936194477df2ff")
+}
+
+func TestRelease(t *testing.T) {
+	one := Init(8)
+
+	Release(8)
+
+	two := Init(8)
+
+	if one == two {
+		t.Errorf("instance was not released properly")
+	}
+}

--- a/singletons_test.go
+++ b/singletons_test.go
@@ -52,4 +52,11 @@ func TestRelease(t *testing.T) {
 	if one == two {
 		t.Errorf("instance was not released properly")
 	}
+
+	buf := []byte("test string")
+	res := fmt.Sprintf("%x", one.Hash(buf))
+
+	if res != "abab21b95cee68a5d70d871161e092530638b3b4bd4e88cadab3a5d6bbcf5f80" {
+		t.Errorf("original singleton was destroyed during release")
+	}
 }

--- a/singletons_test.go
+++ b/singletons_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func testSize(t *testing.T, bits uint64, buf []byte, reference string) {
-	one := Init(bits)
-	two := Init(bits)
+	one := Init(Seed, bits, HashSize, Passes)
+	two := Init(Seed, bits, HashSize, Passes)
 
 	if one != two {
 		t.Errorf("[%d] two separate pointers for singleton: %x and %x", bits, &one, &two)
@@ -43,14 +43,24 @@ func TestInit(t *testing.T) {
 }
 
 func TestRelease(t *testing.T) {
-	one := Init(8)
+	one := Init(Seed, 8, HashSize, Passes)
+	oneB := Init(Seed, 8, HashSize, Passes)
 
-	Release(8)
+	Release(one)
 
-	two := Init(8)
+	two := Init(Seed, 8, HashSize, Passes)
 
-	if one == two {
-		t.Errorf("instance was not released properly")
+	if one != two {
+		t.Errorf("released the instance despite another reference")
+	}
+
+	Release(oneB)
+	Release(two)
+
+	oneB = Init(Seed, 8, HashSize, Passes)
+
+	if one == oneB {
+		t.Errorf("singleton wasn't released after all references destroyed")
 	}
 
 	buf := []byte("test string")


### PR DESCRIPTION
As part of the modular rewrite of pegnet functionality, we needed an independent way to access the LXRHash across several modules. 

This provides a way to access a hashmap singleton from outside the package by calling `lxr.Init(30)`. Multiple calls to the same bitsize will return references to the same lxrhash.

These singletons use the default parameters defined in `constants.go` which were previously unused.