### PR TITLE
Don't pre-allocate ByteMap

### DIFF
--- a/tables.go
+++ b/tables.go
@@ -47,8 +47,6 @@ func (lx *LXRHash) Init(Seed, MapSizeBits, HashSize, Passes uint64) {
 	}
 
 	MapSize := uint64(1) << MapSizeBits
-	lx.ByteMap = make([]byte, int(MapSize))
-
 	lx.HashSize = (HashSize + 7) / 8
 	lx.MapSize = MapSize
 	lx.MapSizeBits = MapSizeBits
@@ -61,7 +59,6 @@ func (lx *LXRHash) Init(Seed, MapSizeBits, HashSize, Passes uint64) {
 // ReadTable attempts to load the ByteMap from disk.
 // If that doesn't exist, a new one will be generated and saved.
 func (lx *LXRHash) ReadTable() {
-
 	u, err := user.Current()
 	if err != nil {
 		panic(err)
@@ -129,7 +126,7 @@ func (lx *LXRHash) WriteTable(filename string) {
 // Initializes the map with an incremental sequence of bytes,
 // then does P passes, shuffling each element in a deterministic manner.
 func (lx *LXRHash) GenerateTable() {
-
+	lx.ByteMap = make([]byte, int(lx.MapSize))
 	// Our own "random" generator that really is just used to shuffle values
 	offset := lx.Seed ^ firstrand
 	b := lx.Seed ^ firstb


### PR DESCRIPTION
closes: https://github.com/pegnet/LXRHash/issues/54

Was looking into improving #54 and I noticed that right now the ByteMap is always allocated on Init, but the function that reads the file returns its own 1GB buffer and then simply overwrites the allocated ByteMap slice. Our high RAM usage may be a result of the golang garbage collector not dealing with this very well.

This change will just use the pointer from ioutil.ReadAll when reading a file (same as before) but now only allocate the ByteMap when GenerateTable is called.

This should limit the ram used to 1GB.

P.S.: I also looked at reading the file in 4 KB chunks but that has significantly worse performance than ioutil's implementation and if this fix works, would actually use 1GB + 4KB of ram instead of just 1GB.