### PR TITLE
Flatten anonymous functions

### DIFF
--- a/benchmark.go
+++ b/benchmark.go
@@ -32,22 +32,18 @@ func benchFunc(ctx context.Context, duration time.Duration, goroutines uint, f f
 		ctx = context.Background()
 	}
 
+	myctx, cancel := context.WithTimeout(ctx, duration)
+	defer cancel()
+
 	var hashes uint64
 	base := make([]byte, 32) // null base is ok
-	myctx, cancel := context.WithCancel(ctx)
 
 	start := time.Now()
 	for i := 0; i < int(goroutines); i++ {
 		go benchMiner(myctx, byte(i), &hashes, base, f)
 	}
 
-	timer := time.NewTimer(duration)
-	select {
-	case <-timer.C:
-	case <-myctx.Done():
-	}
-	cancel()
-
+	<-myctx.Done()
 	return hashes, time.Since(start)
 }
 

--- a/benchmark.go
+++ b/benchmark.go
@@ -1,0 +1,70 @@
+package lxr
+
+import (
+	"context"
+	"encoding/binary"
+	"runtime"
+	"sync/atomic"
+	"time"
+)
+
+// BenchmarkHash will run a benchmark for the specified duration using the regular Hash function.
+// Returns the number of hashes calculated and the real duration of the benchmark.
+// If no goroutines are specified it will use the total number of available cores.
+func (lx LXRHash) BenchmarkHash(ctx context.Context, duration time.Duration, goroutines uint) (uint64, time.Duration) {
+	return benchFunc(ctx, duration, goroutines, lx.Hash)
+}
+
+// BenchmarkHash will run a benchmark for the specified duration using the FlatHash function.
+// Returns the number of hashes calculated and the real duration of the benchmark.
+// If no goroutines are specified it will use the total number of available cores.
+func (lx LXRHash) BenchmarkFlatHash(ctx context.Context, duration time.Duration, goroutines uint) (uint64, time.Duration) {
+	return benchFunc(ctx, duration, goroutines, lx.FlatHash)
+}
+
+// benchmark a specific function. cancels early if context is cancelled, otherwise runs for duration
+func benchFunc(ctx context.Context, duration time.Duration, goroutines uint, f func([]byte) []byte) (uint64, time.Duration) {
+	if goroutines == 0 {
+		goroutines = uint(runtime.NumCPU())
+	}
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	var hashes uint64
+	base := make([]byte, 32) // null base is ok
+	myctx, cancel := context.WithCancel(ctx)
+
+	start := time.Now()
+	for i := 0; i < int(goroutines); i++ {
+		go benchMiner(myctx, byte(i), &hashes, base, f)
+	}
+
+	timer := time.NewTimer(duration)
+	select {
+	case <-timer.C:
+	case <-myctx.Done():
+	}
+	cancel()
+
+	return hashes, time.Since(start)
+}
+
+// individual mining thread
+func benchMiner(ctx context.Context, id byte, count *uint64, base []byte, f func([]byte) []byte) {
+	nonce := append(base, []byte{id, 0, 0, 0, 0}...)
+	pos := len(nonce) - 4
+	i := uint32(0)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			binary.BigEndian.PutUint32(nonce[pos:], i)
+			f(nonce)
+			atomic.AddUint64(count, 1)
+			i++
+		}
+	}
+}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,122 @@
+package lxr
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func Test_benchMiner(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	dupe := make(map[string]bool)
+
+	var count uint64
+	var realCount uint64
+	base := []byte{0xab, 0xab, 0xab}
+	go benchMiner(ctx, 0x55, &count, base, func(in []byte) []byte {
+		str := hex.EncodeToString(in)
+		if dupe[str] {
+			t.Errorf("duplicate nonce: %s", str)
+		}
+		dupe[str] = true
+
+		fmt.Printf("%x\n", in)
+		if !bytes.Equal(base, in[:len(base)]) {
+			t.Errorf("supplied base invalid. want = %x, got = %x", base, in[:len(base)])
+		}
+		realCount++
+		return in
+	})
+
+	time.Sleep(time.Millisecond)
+	cancel()
+
+	if realCount != count {
+		t.Errorf("count mismatch. realCount = %d, count = %d", realCount, count)
+	}
+
+	time.Sleep(time.Millisecond)
+	snapshot := count
+	time.Sleep(time.Millisecond)
+
+	if snapshot != count {
+		t.Errorf("goroutine keeps running. snapshot = %d, count = %d", snapshot, count)
+	}
+}
+
+func Test_benchMiner_concurrent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var mtx sync.Mutex
+	dupe := make(map[string]bool)
+
+	var count uint64
+	base := []byte{0xab, 0xab, 0xab}
+	for i := 0; i < 4; i++ {
+		go benchMiner(ctx, byte(i), &count, base, func(in []byte) []byte {
+			mtx.Lock()
+			str := hex.EncodeToString(in)
+			if dupe[str] {
+				t.Errorf("duplicate nonce: %s", str)
+			}
+			dupe[str] = true
+			mtx.Unlock()
+
+			return nil
+		})
+	}
+
+	time.Sleep(time.Millisecond * 500)
+	cancel()
+}
+
+func Test_benchFunc(t *testing.T) {
+	testFunc := func(_ []byte) []byte {
+		return nil
+	}
+
+	// test duration
+	start := time.Now()
+	hashes, duration := benchFunc(context.Background(), time.Millisecond*100, 1, testFunc)
+	realDuration := time.Since(start)
+
+	if duration > realDuration {
+		t.Errorf("duration reporting wrong. got = %s, real = %s", duration, realDuration)
+	} else if duration == 0 {
+		t.Errorf("zero duration return")
+	}
+
+	if hashes == 0 {
+		t.Errorf("no hashes calculated")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	start = time.Now()
+	go func() {
+		_, duration = benchFunc(ctx, time.Second*2, 1, testFunc)
+		wg.Done()
+	}()
+
+	time.Sleep(time.Millisecond * 500)
+	cancel()
+	cancelDuration := time.Since(start)
+	wg.Wait()
+	realDuration = time.Since(start)
+
+	if realDuration-cancelDuration > time.Second {
+		t.Errorf("Cancelling took too long. cancelDuration = %s, realDuration = %s", cancelDuration, realDuration)
+	}
+
+	if duration-cancelDuration > time.Second {
+		t.Errorf("Cancelling took too long. cancelDuration = %s, benchDuration = %s", cancelDuration, duration)
+	}
+}

--- a/lxrhash.go
+++ b/lxrhash.go
@@ -13,8 +13,124 @@ type LXRHash struct {
 	verbose     bool
 }
 
+func (lx LXRHash) fastStepf(v2, as, s1, s2, s3, idx uint64, hs []uint64) (uint64, uint64, uint64, uint64) {
+	b := uint64(lx.ByteMap[(as^v2)&(lx.MapSize-1)])
+	as = as<<7 ^ as>>5 ^ v2<<20 ^ v2<<16 ^ v2 ^ b<<20 ^ b<<12 ^ b<<4
+	s1 = s1<<9 ^ s1>>3 ^ hs[idx]
+	hs[idx] = s1 ^ as
+	s1, s2, s3 = s3, s1, s2
+	return as, s1, s2, s3
+}
+
+func (lx LXRHash) stepf(as, s1, s2, s3, v2 uint64, hs []uint64, idx uint64, mk uint64) (uint64, uint64, uint64, uint64) {
+	s1 = s1<<9 ^ s1>>1 ^ as ^ uint64(lx.ByteMap[(as>>5^v2)&mk])<<3
+	// Shifts are not random.  They are selected to ensure that
+	s1 = s1<<5 ^ s1>>3 ^ uint64(lx.ByteMap[(s1^v2)&mk])<<7
+	// Prior bytes pulled from the ByteMap contribute to the
+	s1 = s1<<7 ^ s1>>7 ^ uint64(lx.ByteMap[(as^s1>>7)&mk])<<5
+	// next access of the ByteMap, either by contributing to
+	s1 = s1<<11 ^ s1>>5 ^ uint64(lx.ByteMap[(v2^as>>11^s1)&mk])<<27
+	// the lower bits of the index, or in the upper bits that
+	_ = 0
+	// move the access further in the map.
+	hs[idx] = s1 ^ as ^ hs[idx]<<7 ^ hs[idx]>>13
+	//
+	_ = 0
+	// We also pay attention not only to where the ByteMap bits
+	as = as<<17 ^ as>>5 ^ s1 ^ uint64(lx.ByteMap[(as^s1>>27^v2)&mk])<<3
+	// are applied, but what bits we use in the indexing of
+	as = as<<13 ^ as>>3 ^ uint64(lx.ByteMap[(as^s1)&mk])<<7
+	// the ByteMap
+	as = as<<15 ^ as>>7 ^ uint64(lx.ByteMap[(as>>7^s1)&mk])<<11
+	//
+	as = as<<9 ^ as>>11 ^ uint64(lx.ByteMap[(v2^as^s1)&mk])<<3
+	// Tests run against this set of shifts show that the
+	_ = 0
+	// bytes pulled from the ByteMap are evenly distributed
+	s1 = s1<<7 ^ s1>>27 ^ as ^ uint64(lx.ByteMap[(as>>3)&mk])<<13
+	// over possible byte values (0-255) and indexes into
+	s1 = s1<<3 ^ s1>>13 ^ uint64(lx.ByteMap[(s1^v2)&mk])<<11
+	// the ByteMap are also evenly distributed, and the
+	s1 = s1<<8 ^ s1>>11 ^ uint64(lx.ByteMap[(as^s1>>11)&mk])<<9
+	// deltas between bytes provided map to a curve expected
+	s1 = s1<<6 ^ s1>>9 ^ uint64(lx.ByteMap[(v2^as^s1)&mk])<<3
+	// (fewer maximum and minimum deltas, and most deltas around
+	_ = 0
+	// zero.
+	as = as<<23 ^ as>>3 ^ s1 ^ uint64(lx.ByteMap[(as^v2^s1>>3)&mk])<<7
+	as = as<<17 ^ as>>7 ^ uint64(lx.ByteMap[(as^s1>>3)&mk])<<5
+	as = as<<13 ^ as>>5 ^ uint64(lx.ByteMap[(as>>5^s1)&mk])<<1
+	as = as<<11 ^ as>>1 ^ uint64(lx.ByteMap[(v2^as^s1)&mk])<<7
+	s1 = s1<<5 ^ s1>>3 ^ as ^ uint64(lx.ByteMap[(as>>7^s1>>3)&mk])<<6
+	s1 = s1<<8 ^ s1>>6 ^ uint64(lx.ByteMap[(s1^v2)&mk])<<11
+	s1 = s1<<11 ^ s1>>11 ^ uint64(lx.ByteMap[(as^s1>>11)&mk])<<5
+	s1 = s1<<7 ^ s1>>5 ^ uint64(lx.ByteMap[(v2^as>>7^as^s1)&mk])<<17
+	s2 = s2<<3 ^ s2>>17 ^ s1 ^ uint64(lx.ByteMap[(as^s2>>5^v2)&mk])<<13
+	s2 = s2<<6 ^ s2>>13 ^ uint64(lx.ByteMap[(s2)&mk])<<11
+	s2 = s2<<11 ^ s2>>11 ^ uint64(lx.ByteMap[(as^s1^s2>>11)&mk])<<23
+	s2 = s2<<4 ^ s2>>23 ^ uint64(lx.ByteMap[(v2^as>>8^as^s2>>10)&mk])<<1
+	s1 = s2<<3 ^ s2>>1 ^ hs[idx] ^ v2
+	as = as<<9 ^ as>>7 ^ s1>>1 ^ uint64(lx.ByteMap[(s2>>1^hs[idx])&mk])<<5
+
+	s1, s2, s3 = s3, s1, s2
+
+	return as, s1, s2, s3
+}
+
 // Hash takes the arbitrary input and returns the resulting hash of length HashSize
+// Does not use anonymous functions
 func (lx LXRHash) Hash(src []byte) []byte {
+	// Keep the byte intermediate results as int64 values until reduced.
+	hs := make([]uint64, lx.HashSize)
+	// as accumulates the state as we walk through applying the source data through the lookup map
+	// and combine it with the state we are building up.
+	var as = lx.Seed
+	// We keep a series of states, and roll them along through each byte of source processed.
+	var s1, s2, s3 uint64
+	// Since MapSize is specified in bits, the index mask is the size-1
+	mk := lx.MapSize - 1
+
+	idx := uint64(0)
+	// Fast spin to prevent caching state
+	for _, v2 := range src {
+		if idx >= lx.HashSize { // Use an if to avoid modulo math
+			idx = 0
+		}
+
+		as, s1, s2, s3 = lx.fastStepf(uint64(v2), as, s1, s2, s3, idx, hs)
+		idx++
+	}
+
+	idx = 0
+	// Actual work to compute the hash
+	for _, v2 := range src {
+		if idx >= lx.HashSize { // Use an if to avoid modulo math
+			idx = 0
+		}
+
+		as, s1, s2, s3 = lx.stepf(as, s1, s2, s3, uint64(v2), hs, idx, mk)
+		idx++
+	}
+
+	// Reduction pass
+	// Done by Interating over hs[] to produce the bytes[] hash
+	//
+	// At this point, we have HBits of state in hs.  We need to reduce them down to a byte,
+	// And we do so by doing a bit more bitwise math, and mapping the values through our byte map.
+
+	bytes := make([]byte, lx.HashSize)
+	// Roll over all the hs (one int64 value for every byte in the resulting hash) and reduce them to byte values
+	for i := len(hs) - 1; i >= 0; i-- {
+		as, s1, s2, s3 = lx.stepf(as, s1, s2, s3, uint64(hs[i]), hs, uint64(i), mk)
+		bytes[i] = lx.ByteMap[as&mk] ^ lx.ByteMap[hs[i]&mk] // Xor two resulting sequences
+	}
+
+	// Return the resulting hash
+	return bytes
+}
+
+// Hash takes the arbitrary input and returns the resulting hash of length HashSize
+func (lx LXRHash) HashWithAnonFuncs(src []byte) []byte {
 	// Keep the byte intermediate results as int64 values until reduced.
 	hs := make([]uint64, lx.HashSize)
 	// as accumulates the state as we walk through applying the source data through the lookup map

--- a/lxrhash.go
+++ b/lxrhash.go
@@ -77,9 +77,9 @@ func (lx LXRHash) stepf(as, s1, s2, s3, v2 uint64, hs []uint64, idx uint64, mk u
 	return as, s1, s2, s3
 }
 
-// Hash takes the arbitrary input and returns the resulting hash of length HashSize
+// FlatHash takes the arbitrary input and returns the resulting hash of length HashSize
 // Does not use anonymous functions
-func (lx LXRHash) Hash(src []byte) []byte {
+func (lx LXRHash) FlatHash(src []byte) []byte {
 	// Keep the byte intermediate results as int64 values until reduced.
 	hs := make([]uint64, lx.HashSize)
 	// as accumulates the state as we walk through applying the source data through the lookup map
@@ -130,7 +130,7 @@ func (lx LXRHash) Hash(src []byte) []byte {
 }
 
 // Hash takes the arbitrary input and returns the resulting hash of length HashSize
-func (lx LXRHash) HashWithAnonFuncs(src []byte) []byte {
+func (lx LXRHash) Hash(src []byte) []byte {
 	// Keep the byte intermediate results as int64 values until reduced.
 	hs := make([]uint64, lx.HashSize)
 	// as accumulates the state as we walk through applying the source data through the lookup map

--- a/lxrhash_test.go
+++ b/lxrhash_test.go
@@ -5,6 +5,7 @@ package lxr
 import (
 	"bytes"
 	"encoding/hex"
+	"math/rand"
 	"testing"
 )
 
@@ -79,4 +80,14 @@ func TestKnownHashes(t *testing.T) {
 		}
 	}
 
+}
+
+func TestLXRHash_Hash(t *testing.T) {
+	for i := 0; i < 1000; i++ {
+		data := make([]byte, rand.Intn(100))
+		h1, h2 := lx.Hash(data), lx.HashWithAnonFuncs(data)
+		if bytes.Compare(h1, h2) != 0 {
+			t.Errorf("mismatch hashes\n%x\n%x", h1, h2)
+		}
+	}
 }

--- a/lxrhash_test.go
+++ b/lxrhash_test.go
@@ -48,7 +48,7 @@ func BenchmarkHash(b *testing.B) {
 				nonce = append(nonce, byte(j))
 			}
 			no := append(oprhash, nonce...)
-			lx.Hash(no)
+			lx.FlatHash(no)
 		}
 	})
 	b.Run("flat hash again", func(b *testing.B) {
@@ -59,7 +59,7 @@ func BenchmarkHash(b *testing.B) {
 				nonce = append(nonce, byte(j))
 			}
 			no := append(oprhash, nonce...)
-			lx.Hash(no)
+			lx.FlatHash(no)
 		}
 	})
 }

--- a/lxrhash_test.go
+++ b/lxrhash_test.go
@@ -40,6 +40,28 @@ func BenchmarkHash(b *testing.B) {
 			lx.Hash(no)
 		}
 	})
+	b.Run("flat hash", func(b *testing.B) {
+		nonce := []byte{0, 0}
+		for i := 0; i < b.N; i++ {
+			nonce = nonce[:0]
+			for j := i; j > 0; j = j >> 8 {
+				nonce = append(nonce, byte(j))
+			}
+			no := append(oprhash, nonce...)
+			lx.Hash(no)
+		}
+	})
+	b.Run("flat hash again", func(b *testing.B) {
+		nonce := []byte{0, 0}
+		for i := 0; i < b.N; i++ {
+			nonce = nonce[:0]
+			for j := i; j > 0; j = j >> 8 {
+				nonce = append(nonce, byte(j))
+			}
+			no := append(oprhash, nonce...)
+			lx.Hash(no)
+		}
+	})
 }
 
 func TestKnownHashes(t *testing.T) {
@@ -80,12 +102,21 @@ func TestKnownHashes(t *testing.T) {
 		}
 	}
 
+	for k, v := range known {
+		hash := lx.FlatHash([]byte(k))
+		val, _ := hex.DecodeString(v)
+
+		if !bytes.Equal(hash, val) {
+			t.Errorf("flathash mismatch for %s. got = %s, want = %s", k, hex.EncodeToString(hash), v)
+		}
+	}
+
 }
 
 func TestLXRHash_Hash(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		data := make([]byte, rand.Intn(100))
-		h1, h2 := lx.Hash(data), lx.HashWithAnonFuncs(data)
+		h1, h2 := lx.Hash(data), lx.FlatHash(data)
 		if bytes.Compare(h1, h2) != 0 {
 			t.Errorf("mismatch hashes\n%x\n%x", h1, h2)
 		}


### PR DESCRIPTION
I included the old function as well if someone wants to benchmark, but my machine sees a 5K per core to 5.4k per core increase for golang 1.13, and an i7