### PR TITLE
Make FlatHash optional

### DIFF
--- a/lxrhash.go
+++ b/lxrhash.go
@@ -77,9 +77,9 @@ func (lx LXRHash) stepf(as, s1, s2, s3, v2 uint64, hs []uint64, idx uint64, mk u
 	return as, s1, s2, s3
 }
 
-// Hash takes the arbitrary input and returns the resulting hash of length HashSize
+// FlatHash takes the arbitrary input and returns the resulting hash of length HashSize
 // Does not use anonymous functions
-func (lx LXRHash) Hash(src []byte) []byte {
+func (lx LXRHash) FlatHash(src []byte) []byte {
 	// Keep the byte intermediate results as int64 values until reduced.
 	hs := make([]uint64, lx.HashSize)
 	// as accumulates the state as we walk through applying the source data through the lookup map
@@ -130,7 +130,7 @@ func (lx LXRHash) Hash(src []byte) []byte {
 }
 
 // Hash takes the arbitrary input and returns the resulting hash of length HashSize
-func (lx LXRHash) HashWithAnonFuncs(src []byte) []byte {
+func (lx LXRHash) Hash(src []byte) []byte {
 	// Keep the byte intermediate results as int64 values until reduced.
 	hs := make([]uint64, lx.HashSize)
 	// as accumulates the state as we walk through applying the source data through the lookup map

--- a/lxrhash_test.go
+++ b/lxrhash_test.go
@@ -48,7 +48,7 @@ func BenchmarkHash(b *testing.B) {
 				nonce = append(nonce, byte(j))
 			}
 			no := append(oprhash, nonce...)
-			lx.Hash(no)
+			lx.FlatHash(no)
 		}
 	})
 	b.Run("flat hash again", func(b *testing.B) {
@@ -59,7 +59,7 @@ func BenchmarkHash(b *testing.B) {
 				nonce = append(nonce, byte(j))
 			}
 			no := append(oprhash, nonce...)
-			lx.Hash(no)
+			lx.FlatHash(no)
 		}
 	})
 }

--- a/lxrhash_test.go
+++ b/lxrhash_test.go
@@ -40,6 +40,28 @@ func BenchmarkHash(b *testing.B) {
 			lx.Hash(no)
 		}
 	})
+	b.Run("flat hash", func(b *testing.B) {
+		nonce := []byte{0, 0}
+		for i := 0; i < b.N; i++ {
+			nonce = nonce[:0]
+			for j := i; j > 0; j = j >> 8 {
+				nonce = append(nonce, byte(j))
+			}
+			no := append(oprhash, nonce...)
+			lx.Hash(no)
+		}
+	})
+	b.Run("flat hash again", func(b *testing.B) {
+		nonce := []byte{0, 0}
+		for i := 0; i < b.N; i++ {
+			nonce = nonce[:0]
+			for j := i; j > 0; j = j >> 8 {
+				nonce = append(nonce, byte(j))
+			}
+			no := append(oprhash, nonce...)
+			lx.Hash(no)
+		}
+	})
 }
 
 func TestKnownHashes(t *testing.T) {
@@ -80,12 +102,21 @@ func TestKnownHashes(t *testing.T) {
 		}
 	}
 
+	for k, v := range known {
+		hash := lx.FlatHash([]byte(k))
+		val, _ := hex.DecodeString(v)
+
+		if !bytes.Equal(hash, val) {
+			t.Errorf("flathash mismatch for %s. got = %s, want = %s", k, hex.EncodeToString(hash), v)
+		}
+	}
+
 }
 
 func TestLXRHash_Hash(t *testing.T) {
 	for i := 0; i < 1000; i++ {
 		data := make([]byte, rand.Intn(100))
-		h1, h2 := lx.Hash(data), lx.HashWithAnonFuncs(data)
+		h1, h2 := lx.Hash(data), lx.FlatHash(data)
 		if bytes.Compare(h1, h2) != 0 {
 			t.Errorf("mismatch hashes\n%x\n%x", h1, h2)
 		}


### PR DESCRIPTION
Setting the default to the original and providing FlatHash as an optional alternative. Also added a unit test for known hash checks for FlatHash.