### PR TITLE
Package benchmarking functions

### DIFF
--- a/benchmark.go
+++ b/benchmark.go
@@ -32,22 +32,18 @@ func benchFunc(ctx context.Context, duration time.Duration, goroutines uint, f f
 		ctx = context.Background()
 	}
 
+	myctx, cancel := context.WithTimeout(ctx, duration)
+	defer cancel()
+
 	var hashes uint64
 	base := make([]byte, 32) // null base is ok
-	myctx, cancel := context.WithCancel(ctx)
 
 	start := time.Now()
 	for i := 0; i < int(goroutines); i++ {
 		go benchMiner(myctx, byte(i), &hashes, base, f)
 	}
 
-	timer := time.NewTimer(duration)
-	select {
-	case <-timer.C:
-	case <-myctx.Done():
-	}
-	cancel()
-
+	<-myctx.Done()
 	return hashes, time.Since(start)
 }
 

--- a/benchmark.go
+++ b/benchmark.go
@@ -1,0 +1,70 @@
+package lxr
+
+import (
+	"context"
+	"encoding/binary"
+	"runtime"
+	"sync/atomic"
+	"time"
+)
+
+// BenchmarkHash will run a benchmark for the specified duration using the regular Hash function.
+// Returns the number of hashes calculated and the real duration of the benchmark.
+// If no goroutines are specified it will use the total number of available cores.
+func (lx LXRHash) BenchmarkHash(ctx context.Context, duration time.Duration, goroutines uint) (uint64, time.Duration) {
+	return benchFunc(ctx, duration, goroutines, lx.Hash)
+}
+
+// BenchmarkHash will run a benchmark for the specified duration using the FlatHash function.
+// Returns the number of hashes calculated and the real duration of the benchmark.
+// If no goroutines are specified it will use the total number of available cores.
+func (lx LXRHash) BenchmarkFlatHash(ctx context.Context, duration time.Duration, goroutines uint) (uint64, time.Duration) {
+	return benchFunc(ctx, duration, goroutines, lx.FlatHash)
+}
+
+// benchmark a specific function. cancels early if context is cancelled, otherwise runs for duration
+func benchFunc(ctx context.Context, duration time.Duration, goroutines uint, f func([]byte) []byte) (uint64, time.Duration) {
+	if goroutines == 0 {
+		goroutines = uint(runtime.NumCPU())
+	}
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	var hashes uint64
+	base := make([]byte, 32) // null base is ok
+	myctx, cancel := context.WithCancel(ctx)
+
+	start := time.Now()
+	for i := 0; i < int(goroutines); i++ {
+		go benchMiner(myctx, byte(i), &hashes, base, f)
+	}
+
+	timer := time.NewTimer(duration)
+	select {
+	case <-timer.C:
+	case <-myctx.Done():
+	}
+	cancel()
+
+	return hashes, time.Since(start)
+}
+
+// individual mining thread
+func benchMiner(ctx context.Context, id byte, count *uint64, base []byte, f func([]byte) []byte) {
+	nonce := append(base, []byte{id, 0, 0, 0, 0}...)
+	pos := len(nonce) - 4
+	i := uint32(0)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			binary.BigEndian.PutUint32(nonce[pos:], i)
+			f(nonce)
+			atomic.AddUint64(count, 1)
+			i++
+		}
+	}
+}

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,122 @@
+package lxr
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func Test_benchMiner(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	dupe := make(map[string]bool)
+
+	var count uint64
+	var realCount uint64
+	base := []byte{0xab, 0xab, 0xab}
+	go benchMiner(ctx, 0x55, &count, base, func(in []byte) []byte {
+		str := hex.EncodeToString(in)
+		if dupe[str] {
+			t.Errorf("duplicate nonce: %s", str)
+		}
+		dupe[str] = true
+
+		fmt.Printf("%x\n", in)
+		if !bytes.Equal(base, in[:len(base)]) {
+			t.Errorf("supplied base invalid. want = %x, got = %x", base, in[:len(base)])
+		}
+		realCount++
+		return in
+	})
+
+	time.Sleep(time.Millisecond)
+	cancel()
+
+	if realCount != count {
+		t.Errorf("count mismatch. realCount = %d, count = %d", realCount, count)
+	}
+
+	time.Sleep(time.Millisecond)
+	snapshot := count
+	time.Sleep(time.Millisecond)
+
+	if snapshot != count {
+		t.Errorf("goroutine keeps running. snapshot = %d, count = %d", snapshot, count)
+	}
+}
+
+func Test_benchMiner_concurrent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var mtx sync.Mutex
+	dupe := make(map[string]bool)
+
+	var count uint64
+	base := []byte{0xab, 0xab, 0xab}
+	for i := 0; i < 4; i++ {
+		go benchMiner(ctx, byte(i), &count, base, func(in []byte) []byte {
+			mtx.Lock()
+			str := hex.EncodeToString(in)
+			if dupe[str] {
+				t.Errorf("duplicate nonce: %s", str)
+			}
+			dupe[str] = true
+			mtx.Unlock()
+
+			return nil
+		})
+	}
+
+	time.Sleep(time.Millisecond * 500)
+	cancel()
+}
+
+func Test_benchFunc(t *testing.T) {
+	testFunc := func(_ []byte) []byte {
+		return nil
+	}
+
+	// test duration
+	start := time.Now()
+	hashes, duration := benchFunc(context.Background(), time.Millisecond*100, 1, testFunc)
+	realDuration := time.Since(start)
+
+	if duration > realDuration {
+		t.Errorf("duration reporting wrong. got = %s, real = %s", duration, realDuration)
+	} else if duration == 0 {
+		t.Errorf("zero duration return")
+	}
+
+	if hashes == 0 {
+		t.Errorf("no hashes calculated")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	start = time.Now()
+	go func() {
+		_, duration = benchFunc(ctx, time.Second*2, 1, testFunc)
+		wg.Done()
+	}()
+
+	time.Sleep(time.Millisecond * 500)
+	cancel()
+	cancelDuration := time.Since(start)
+	wg.Wait()
+	realDuration = time.Since(start)
+
+	if realDuration-cancelDuration > time.Second {
+		t.Errorf("Cancelling took too long. cancelDuration = %s, realDuration = %s", cancelDuration, realDuration)
+	}
+
+	if duration-cancelDuration > time.Second {
+		t.Errorf("Cancelling took too long. cancelDuration = %s, benchDuration = %s", cancelDuration, duration)
+	}
+}


### PR DESCRIPTION
Per https://github.com/pegnet/LXRHash/pull/61#issuecomment-573719430, the goal is to have official benchmarking functions that can be easily used by other packages.

You call these functions with a context, duration, and number of goroutines ("0" means it will use runtime.NumCPU()) and get the number of hashes and actual duration. 

A simple benchmark app would then look like:
```
func main() {
	var lx lxr.LXRHash
	lx.Init(lxr.Seed, lxr.MapSizeBits, lxr.HashSize, lxr.Passes)

	hashes, dur := lx.BenchmarkHash(context.Background(), time.Second*5, 0)
	fmt.Println("Hash", hashes, dur, float64(hashes)/dur.Seconds())

	hashes, dur = lx.BenchmarkFlatHash(context.Background(), time.Second*5, 0)
	fmt.Println("FlatHash", hashes, dur, float64(hashes)/dur.Seconds())
}
```